### PR TITLE
Add `nmodes` parameter for setting/getting extents.

### DIFF
--- a/src/tapp/tensor.h
+++ b/src/tapp/tensor.h
@@ -14,27 +14,32 @@ typedef intptr_t TAPP_tensor_info;
 
 TAPP_error TAPP_create_tensor_info(TAPP_tensor_info* info,
                                    TAPP_datatype type,
-                                   int nmode,
+                                   int nmodes,
                                    const int64_t* extents,
                                    const int64_t* strides);
 
 TAPP_error TAPP_destroy_tensor_info(TAPP_tensor_info info);
 
-int TAPP_get_nmodes(TAPP_tensor_info info);
+TAPP_error TAPP_get_nmodes(TAPP_tensor_info info,
+                           int* nmodes);
 
 TAPP_error TAPP_set_nmodes(TAPP_tensor_info info,
                            int nmodes);
 
-void TAPP_get_extents(TAPP_tensor_info info,
-                      int64_t* extents);
+TAPP_error TAPP_get_extents(TAPP_tensor_info info,
+                            int nmodes,
+                            int64_t* extents);
 
 TAPP_error TAPP_set_extents(TAPP_tensor_info info,
+                            int nmodes,
                             const int64_t* extents);
 
-void TAPP_get_strides(TAPP_tensor_info info,
-                      int64_t* strides);
+TAPP_error TAPP_get_strides(TAPP_tensor_info info,
+                            int nmodes,
+                            int64_t* strides);
 
 TAPP_error TAPP_set_strides(TAPP_tensor_info info,
+                            int nmodes,
                             const int64_t* strides);
 
 #endif /* TAPP_TENSOR_H_ */


### PR DESCRIPTION
For getting and setting both extents and strides, have the user provide an additional `nmodes` parameter which is the maximum number of values to return in the provided extent/stride array. If the number of modes provided is smaller than the number of modes in the tensor, truncate the returned information and return an error.

Fixes #13.