### PR TITLE
Fix destructors and add some constructors.

### DIFF
--- a/src/tapp/attributes.h
+++ b/src/tapp/attributes.h
@@ -8,7 +8,11 @@
 typedef intptr_t TAPP_attr;
 typedef int TAPP_key;
 
-//TODO: predefined attributes? error conditions?
+#define TAPP_NO_ATTRIBUTES ((TAPP_attr)NULL)
+
+TAPP_error TAPP_create_attr(TAPP_attr* attr);
+
+TAPP_error TAPP_destroy_attr(TAPP_attr* attr);
 
 TAPP_error TAPP_attr_set(TAPP_attr attr, TAPP_key key, void* value);
 

--- a/src/tapp/error.h
+++ b/src/tapp/error.h
@@ -12,15 +12,12 @@ bool TAPP_check_success(TAPP_error error);
 /*
  * Fill a user-provided buffer with an implementation-defined string explaining the error code. No more than maxlen-1
  * characters will be written. If maxlen is greater than zero, then a terminating null character is also
- * written. The actual number of characters written is returned, not including the terminating null character.
- * If maxlen is zero, then no characters are written and instead the length of the full string which would have been
- * written is returned, not including the terminating null character. This means that the message written will always
- * be null-terminated.
- *
- * TODO: should the null character be included in the return value?
+ * written. If fewer characters were written than in the full explanation (i.e. the output is truncated), then the
+ * number of characters required (including the terminating null character) is returned in maxlen. Also, if maxlen != 0
+ * an error code is returned (TODO: which one).
  */
-size_t TAPP_explain_error(TAPP_error error,
-                          size_t maxlen,
-                          char* message);
+TAPP_error TAPP_explain_error(TAPP_error error,
+                              size_t* maxlen,
+                              char* message);
 
 #endif /* TAPP_ERROR_H_ */

--- a/src/tapp/executor.h
+++ b/src/tapp/executor.h
@@ -3,15 +3,14 @@
 
 #include <stdint.h>
 
+#include "attributes.h"
 #include "error.h"
+#include "handle.h"
 
 typedef intptr_t TAPP_executor;
 
-/*
- * TODO: implementation-defined creation of executors or "wrapper" to get all implementations and select one?
- *       devices probably can't be enumerated until you have a handle....
- */
+TAPP_error TAPP_create_executor(TAPP_handle handle, TAPP_attr attr);
 
-TAPP_error TAPP_destroy_executor(TAPP_executor exec);
+TAPP_error TAPP_destroy_executor(TAPP_executor* exec);
 
 #endif /* TAPP_HANDLE_H_ */

--- a/src/tapp/handle.h
+++ b/src/tapp/handle.h
@@ -3,21 +3,19 @@
 
 #include <stdint.h>
 
+#include "attributes.h"
 #include "error.h"
 
 typedef intptr_t TAPP_handle;
 
-/*
- * TODO: implementation-defined creation of handles or "wrapper" to get all implementations and select one?
- *       devices probably can't be enumerated until you have a handle....
- */
+//TODO: get string describing implementation?
 
- //TODO: get string describing implementation?
+//TODO: API versioning and query
 
- //TODO: API versioning and query
+//TODO: optional APIs with feature test macros
 
- //TODO: optional APIs with feature test macros
+TAPP_error TAPP_create_handle(TAPP_attr attr);
 
-TAPP_error TAPP_destroy_handle(TAPP_handle handle);
+TAPP_error TAPP_destroy_handle(TAPP_handle* handle);
 
 #endif /* TAPP_HANDLE_H_ */

--- a/src/tapp/product.h
+++ b/src/tapp/product.h
@@ -26,10 +26,10 @@ enum
  * TODO: what are the required error conditions?
  *
  * TODO: must C and D info be the same? (should they just be the same variable?)
- *  JB: Can this be implemented efficiently with different data types of C and D? 
+ *  JB: Can this be implemented efficiently with different data types of C and D?
  *      Let’s say D is complex and C real. Then it should be possible with a different "stride".
- *      In such cases we might want to support different C and D info. If D info is null, they 
- *      are assumed identical. 
+ *      In such cases we might want to support different C and D info. If D info is null, they
+ *      are assumed identical.
  */
 
 typedef intptr_t TAPP_tensor_product;
@@ -52,7 +52,7 @@ TAPP_error TAPP_create_tensor_product(TAPP_tensor_product* plan,
                                       const int64_t* idx_D,
                                       TAPP_prectype prec);
 
-TAPP_error TAPP_destroy_tensor_product(TAPP_tensor_product plan);
+TAPP_error TAPP_destroy_tensor_product(TAPP_tensor_product* plan);
 
 //TODO: in-place operation: set C = NULL or TAPP_IN_PLACE?
 

--- a/src/tapp/status.h
+++ b/src/tapp/status.h
@@ -13,6 +13,8 @@ typedef intptr_t TAPP_status;
  * TODO: how to get data out? using attributes or separate standardized interface? implementation-defined?
  */
 
-TAPP_error TAPP_destroy_status(TAPP_status status);
+#define TAPP_NO_STATUS NULL
+
+TAPP_error TAPP_destroy_status(TAPP_status* status);
 
 #endif /* TAPP_STATUS_H_ */

--- a/src/tapp/tensor.h
+++ b/src/tapp/tensor.h
@@ -18,7 +18,7 @@ TAPP_error TAPP_create_tensor_info(TAPP_tensor_info* info,
                                    const int64_t* extents,
                                    const int64_t* strides);
 
-TAPP_error TAPP_destroy_tensor_info(TAPP_tensor_info info);
+TAPP_error TAPP_destroy_tensor_info(TAPP_tensor_info* info);
 
 TAPP_error TAPP_get_nmodes(TAPP_tensor_info info,
                            int* nmodes);


### PR DESCRIPTION
Add constructors for TAPP_attr, TAPP_handle, and TAPP_executor. The latter make use of the former to provide context and configuration for construction. For all destructors, pass a pointer to the object handle so that it can be reset to NULL or another neutral value. This prevents double-free, use-after-free, etc.

Fixes #15.